### PR TITLE
Parser: values are case-insensitive

### DIFF
--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -96,7 +96,7 @@ fn consume_string(tokens: &mut Vec<Token>) -> Result<String, Error> {
 impl Command {
     pub(crate) fn consume(tokens: &mut Vec<Token>) -> Result<Command, Error> {
         let keyword = consume_string(tokens)?;
-        match keyword.as_str() {
+        match keyword.to_uppercase().as_str() {
             "CATALOG" => Ok(Command::Catalog(format!("{:013}", consume_number(tokens)?))),
             "CDTEXTFILE" => Ok(Command::Cdtextfile(consume_string(tokens)?)),
             "FILE" => Ok(Command::File(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -141,12 +141,12 @@ impl FromStr for FileFormat {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_uppercase().as_str() {
             "WAVE" => Ok(FileFormat::Wave),
             "MP3" => Ok(FileFormat::Mp3),
             "AIFF" => Ok(FileFormat::Aiff),
-            "Binary" => Ok(FileFormat::Binary),
-            "Motorola" => Ok(FileFormat::Motorola),
+            "BINARY" => Ok(FileFormat::Binary),
+            "MOTOROLA" => Ok(FileFormat::Motorola),
             _ => Err(format!("Invalid FileFormat: {:?}", s).into()),
         }
     }
@@ -172,7 +172,7 @@ impl FromStr for TrackFlag {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_uppercase().as_str() {
             "DCP" => Ok(TrackFlag::Dcp),
             "4CH" => Ok(TrackFlag::FourChannel),
             "PRE" => Ok(TrackFlag::Pre),
@@ -210,7 +210,7 @@ impl FromStr for TrackType {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_uppercase().as_str() {
             "AUDIO" => Ok(TrackType::Audio),
             "CDG" => Ok(TrackType::Cdg),
             "MODE1/2048" => Ok(TrackType::Mode(1, 2048)),


### PR DESCRIPTION
The CUE sheet format's keywords and commands are all case-insensitive; this converts the values to uppercase before comparing. It fixes parsing a CUE sheet I had with `BINARY` (all-caps), which triggered a `Invalid FileFormat: BINARY` error.