### PR TITLE
Add pregap parsing support

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -62,11 +62,13 @@ impl Time {
         format!("{:02}:{:02}", self.mins, self.secs)
     }
 
-    fn to_frames(&self) -> i64 {
+    /// Returns the number of sectors represented by this Time.
+    pub fn to_frames(&self) -> i64 {
         ((self.mins * 60) as i64 + self.secs as i64) * FPS + self.frames as i64
     }
 
-    fn from_frames(from: i64) -> Time {
+    /// Converts a sector count into a Time.
+    pub fn from_frames(from: i64) -> Time {
         let frames = from % FPS;
         let secs_all = from / FPS;
         let secs = secs_all % 60;

--- a/src/tracklist.rs
+++ b/src/tracklist.rs
@@ -184,6 +184,20 @@ impl Track {
                         title = Some(t);
                         commands.remove(0);
                     }
+                    Command::Pregap(time) => {
+                        let next_command = commands.get(1).ok_or("Pregap is the last command in the track!".to_owned())?.to_owned();
+
+                        let first_index;
+                        match next_command {
+                            Command::Index(_, time) => first_index = time,
+                            _ => {
+                                return Err("Pregap is not followed by an index!".into());
+                            }
+                        }
+                        let diff = first_index.to_frames() - time.to_frames();
+                        index.push((0, Time::from_frames(diff)));
+                        commands.remove(0);
+                    }
                     Command::Index(i, time) => {
                         index.push((i, time));
                         commands.remove(0);


### PR DESCRIPTION
This adds pregap parsing support to the command processing.

Since pregaps are a relative time, not an absolute time like the `INDEX` field, I promoted `Time`'s `to_frames` and `from_frames` methods to the public API. I needed those fields anyway, since my usecases require sector counts. :)

~The peek of `commands[1]` is probably not safe.~ I've replaced this with a safe form.

Fixes #6.